### PR TITLE
Fix problem setup after Valid -> ValidIO change

### DIFF
--- a/problems/src/main/scala/RealGCD.scala
+++ b/problems/src/main/scala/RealGCD.scala
@@ -12,7 +12,7 @@ class RealGCDInput extends Bundle {
 class RealGCD extends Module {
   val io  = new Bundle {
     val in  = Decoupled(new RealGCDInput()).flip()
-    val out = new Valid(Bits(width = 16))
+    val out = new ValidIO(Bits(width = 16))
   }
 
   // flush this out ...


### PR DESCRIPTION
The 'problems' fail to build because Valid was renamed to ValidIO. After this patch, the checked in problems still fail because they're not implemented, but they at least compile.
