### PR TITLE
Add scalac options to quiet compiler warnings.

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -8,3 +8,5 @@ scalaVersion := "2.10.2"
 
 addSbtPlugin("com.github.scct" % "sbt-scct" % "0.2")
 
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
+

--- a/hello/build.sbt
+++ b/hello/build.sbt
@@ -4,7 +4,5 @@ resolvers ++= Seq(
   "scct-github-repository" at "http://mtkopone.github.com/scct/maven-repo"
 )
 
-libraryDependencies += 
-  "edu.berkeley.cs" %% "chisel" % "latest.release"
-
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
 

--- a/problems/build.sbt
+++ b/problems/build.sbt
@@ -8,3 +8,5 @@ scalaVersion := "2.10.2"
 
 addSbtPlugin("com.github.scct" % "sbt-scct" % "0.2")
 
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
+

--- a/solutions/build.sbt
+++ b/solutions/build.sbt
@@ -8,3 +8,5 @@ scalaVersion := "2.10.2"
 
 addSbtPlugin("com.github.scct" % "sbt-scct" % "0.2")
 
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
+


### PR DESCRIPTION
We use the "-language:reflectiveCalls" feature to access structure fields for wiring (":="). Enable the feature to quiet compiler warnings.
Add scalac options to complain about questionable usage of other features.
