### PR TITLE
Remove .SHELLFLAGS variable

### DIFF
--- a/suffix.mk
+++ b/suffix.mk
@@ -1,15 +1,6 @@
 SBT          ?= sbt
 SBT_FLAGS    ?= -Dsbt.log.noformat=true
 
-# Invoke recipes passing the shell '-e -o pipefail' flags: the first
-# failing command in a recipe will cause the recipe to fail immediately.
-# Otherwise, if a pipeline is involved, the exit code will be the exit code
-# of the last element of the pipeline, which if we're using 'tee", will
-# always be 'true' (success).
-.SHELLFLAGS	:= -e -o pipefail
-# Unfortunately, GNU Make 3.81 doesn't support/honor this, so we need to
-# be explicit and add the options to individual commands.
-
 # If a chiselVersion is defined, use that.
 ifneq (,$(chiselVersion))
 CHISEL_SMOKE_VERSION	:= $(chiselVersion)


### PR DESCRIPTION
With make 4.0 and 4.1 the .SHELLFLAGS variable changes the behavior
of make and causes a "No such file or directory" error:

   wink@desktop:~/prgs/chisel/chisel-tutorial-fork/examples$ make Parity.out
   set -e -o pipefail; sbt -Dsbt.log.noformat=true "run Parity --genHarness --compile --test --backend c " | tee Parity.out
   /bin/sh: set -e -o pipefail; sbt -Dsbt.log.noformat=true "run Parity --genHarness --compile --test --backend c " | tee Parity.out: No such file or directory
   ../suffix.mk:66: recipe for target 'Parity.out' failed
   make: *** [Parity.out] Error 1


The I simplified the "%.out" target so that it was just an empty $(SBT):

  %.out: %.scala
           $(SBT)

And then the true reason for the "No such file or directory" is that
sbt-launcher-lib.bash script can not be found because the current working
directory is "incorrect":

   wink@desktop:~/prgs/chisel/chisel-tutorial-fork/examples$ make Parity.out
   sbt
   /opt/sbt/bin/sbt: line 59: /home/wink/prgs/chisel/chisel-tutorial-fork/examples/sbt-launch-lib.bash: No such file or directory
   ../suffix.mk:64: recipe for target 'Parity.out' failed
   make: *** [Parity.out] Error 1


To me this seems to be a bug with make but we're not going to change make
so the best solution seems to be just remove the .SHELLFLAGS variable.
With it removed the code works with make 3.81, 4.0 and 4.1.