### PR TITLE
Add quotes to $(SBT) to allow spaces in path to SBT.

### DIFF
--- a/suffix.mk
+++ b/suffix.mk
@@ -2,12 +2,12 @@ SBT          ?= sbt
 SBT_FLAGS    ?= -Dsbt.log.noformat=true
 
 # If a chiselVersion is defined, use that.
-# Otherwise, if we're making either "smoke" or "check" use the snapshot.
+# Otherwise, if we're making "smoke" use the snapshot.
 # Otherwise, use the latest release.
 ifneq (,$(chiselVersion))
 SBT_FLAGS += -DchiselVersion="$(chiselVersion)"
 else
-ifneq (,$(filter smoke check,$(MAKECMDGOALS)))
+ifneq (,$(filter smoke,$(MAKECMDGOALS)))
 SBT_FLAGS += -DchiselVersion="2.3-SNAPSHOT"
 else
 SBT_FLAGS += -DchiselVersion="latest.release"
@@ -49,15 +49,15 @@ test-solutions.xml: $(tut_outs)
 # We should be able to do this with .POSIX: or .SHELLFLAGS but they don't
 # appear to be support by Make 3.81
 %.out: %.scala
-	set -e -o pipefail; $(SBT) $(SBT_FLAGS) "run $(notdir $(basename $<)) --genHarness --compile --test --backend c --vcd $(CHISEL_FLAGS)" | tee $@
+	set -e -o pipefail; "$(SBT)" $(SBT_FLAGS) "run $(notdir $(basename $<)) --genHarness --compile --test --backend c --vcd $(CHISEL_FLAGS)" | tee $@
 
 %.hex: %.scala
-	$(SBT) $(SBT_FLAGS) "run $(notdir $(basename $<)) --backend flo --genHarness --compile --test $(CHISEL_FLAGS)"
+	"$(SBT)" $(SBT_FLAGS) "run $(notdir $(basename $<)) --backend flo --genHarness --compile --test $(CHISEL_FLAGS)"
 
 %.v: %.scala
-	$(SBT) $(SBT_FLAGS) "run $(notdir $(basename $<)) --genHarness --backend v $(CHISEL_FLAGS)"
+	"$(SBT)" $(SBT_FLAGS) "run $(notdir $(basename $<)) --genHarness --backend v $(CHISEL_FLAGS)"
 
 smoke:
-	$(SBT) $(SBT_FLAGS) compile
+	"$(SBT)" $(SBT_FLAGS) compile
 
 .PHONY: all check clean emulator verilog smoke


### PR DESCRIPTION
I was going through the tutorial with a new user and some basic things were broken.

This resolves #32. It also makes the target "check" use the latest.release version instead of
snapshot (without doing that, the default make target will crash for users who haven't published a local version of chisel).