### PR TITLE
fix enable & reset shift register tests

### DIFF
--- a/examples/EnableShiftRegister.scala
+++ b/examples/EnableShiftRegister.scala
@@ -29,7 +29,7 @@ class EnableShiftRegister extends Module {
 class EnableShiftRegisterTests(c: EnableShiftRegister) extends Tester(c) {  
   val reg = Array.fill(4){ 0 }
   for (t <- 0 until 16) {
-    val in    = rnd.nextInt(2)
+    val in    = rnd.nextInt(16)
     val shift = rnd.nextInt(2)
     poke(c.io.in,    in)
     poke(c.io.shift, shift)

--- a/examples/ResetShiftRegister.scala
+++ b/examples/ResetShiftRegister.scala
@@ -26,7 +26,7 @@ class ResetShiftRegisterTests(c: ResetShiftRegister) extends Tester(c) {
   val ins = Array.fill(5){ 0 }
   var k   = 0
   for (n <- 0 until 16) {
-    val in    = rnd.nextInt(2)
+    val in    = rnd.nextInt(16)
     val shift = rnd.nextInt(2)
     if (shift == 1) 
       ins(k % 5) = in
@@ -35,6 +35,6 @@ class ResetShiftRegisterTests(c: ResetShiftRegister) extends Tester(c) {
     step(1)
     if (shift == 1)
       k = k + 1
-    expect(c.io.out, (if (n < 4) 0 else ins((k + 1) % 5)))
+    expect(c.io.out, (if (n < 3) 0 else ins((k + 1) % 5)))
   }
 }


### PR DESCRIPTION
a bug appears when shift is always 1 in ResetShiftRegisterTests

inputs can be up to 15