### PR TITLE
General (+Chisel3 compatibility) cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ top_srcdir  ?= .
 include objdirroot.mk
 
 # Directories removed by make clean
-RM_DIRS 	:= emulator project/target target
+RM_DIRS 	:= emulator project/target target $(objdirroot)
 
 # All subdirectories
 ALL_SUB_DIRS	:= examples hello problems solutions
@@ -67,8 +67,7 @@ jenkins-build:	clean smoke check
 # GenSubDirTargets generates a dependency:
 # clean: $(_cleaners)
 clean:
-	$(RM) $(objdirroot)/test-solutions.xml
-	if [ "$(RM_DIRS)" ] ; then $(RM) -r $(RM_DIRS); fi
+	if [ -n "$(RM_DIRS)" ] ; then $(RM) -r $(RM_DIRS); fi
 
 # GenSubDirTargets generates dependencies:
 # smoke: $(_smokeers)

--- a/sbt/check
+++ b/sbt/check
@@ -16,7 +16,7 @@ def main(args, junit_file):
             test_status = 'FAILED'
             test_time = 0
             for line in outfile.readlines():
-                look = re.match(r'RAN \d+ CYCLES (PASSED)|(FAILED)', line)
+                look = re.match(r'RAN \d+ CYCLES (PASSED)|(FAILED)', line) or re.match(r'(PASSED|FAILED)', line)
                 if look:
                     test_status = look.group(1)
                 look = re.match(r'.*Total time: (\S+) s,', line)

--- a/suffix.mk
+++ b/suffix.mk
@@ -53,7 +53,7 @@ default: all
 
 all: outs verilog # dreamer
 
-check: $(objdir)/test-solutions.xml
+check: $(objdir) $(objdir)/test-solutions.xml
 
 clean: $(filter-out $(wildcard $objdir),$(objdir)) $(objdir)
 	cd $(objdir) && $(RM) $(generated_files)


### PR DESCRIPTION
Have top level clean remove entire generated output directory.
Have check script look for either old or new PASSED|FAILED lines - I realize supporting both introduces a level of ambiguity. Supposedly we have enough control over this to reduce the likelihood to zero.
Have the check target dependent on the generated output directory.