### PR TITLE
Fix typo in tutorial

### DIFF
--- a/doc/tutorial/tutorial-3.tex
+++ b/doc/tutorial/tutorial-3.tex
@@ -1971,7 +1971,7 @@ fifo.io.deq.ready := condB
 
 \subsection{Backend Specific Multiple Clock Domains}
 
-Each Chisel backend requires the user to setup up and control multiple clocks
+Each Chisel backend requires the user to setup and control multiple clocks
 in a backend specific manner.  For the purposes of showing how to drive a
 multi clock design, consider the example of hardware with two modules
 communicating using an AsyncFifo with each module on separate clocks:

--- a/doc/tutorial/tutorial.tex
+++ b/doc/tutorial/tutorial.tex
@@ -1971,7 +1971,7 @@ fifo.io.deq.ready := condB
 
 \subsection{Backend Specific Multiple Clock Domains}
 
-Each Chisel backend requires the user to setup up and control multiple clocks
+Each Chisel backend requires the user to setup and control multiple clocks
 in a backend specific manner.  For the purposes of showing how to drive a
 multi clock design, consider the example of hardware with two modules
 communicating using an AsyncFifo with each module on separate clocks:


### PR DESCRIPTION
I read through this useful document and noticed "setup up" is not a common term.