### PR TITLE
define the shell in suffix.mk file

### DIFF
--- a/hello/Makefile
+++ b/hello/Makefile
@@ -1,5 +1,3 @@
-SHELL=/bin/bash
-
 top_srcdir  ?= ..
 
 include $(top_srcdir)/suffix.mk

--- a/suffix.mk
+++ b/suffix.mk
@@ -1,3 +1,5 @@
+SHELL        = /bin/bash
+
 SBT          ?= sbt
 SBT_FLAGS    ?= -Dsbt.log.noformat=true
 


### PR DESCRIPTION
Previously `SHELL` was only defined in the makefile of hello. However,
the same definition is required for the examples makefile. Otherwise,
`set -e -o pipefail` fails there.