### PR TITLE
Adding VendingMachineSwitch to launcher and adding VendingMachineSwit…

### DIFF
--- a/src/test/scala/problems/Launcher.scala
+++ b/src/test/scala/problems/Launcher.scala
@@ -58,7 +58,10 @@ object Launcher {
     (c) => new CounterTest(c)} },
     "VendingMachine" -> { (backendName: String) =>
       Driver(() => new VendingMachine(), backendName){
-    (c) => new VendingMachineTests(c) }}
+    (c) => new VendingMachineTests(c)} },
+    "VendingMachineSwitch" -> { (backendName: String) =>
+      Driver(() => new VendingMachineSwitch(), backendName){
+    (c) => new VendingMachineSwitchTests(c)} }
   )
 
   def main(args: Array[String]): Unit = {

--- a/src/test/scala/problems/VendingMachineSwitch.scala
+++ b/src/test/scala/problems/VendingMachineSwitch.scala
@@ -1,0 +1,26 @@
+// See LICENSE.txt for license details.
+package problems
+
+import Chisel.iotesters.PeekPokeTester
+
+class VendingMachineSwitchTests(c: VendingMachineSwitch) extends PeekPokeTester(c) {
+  var money = 0
+  var isValid = false
+  for (t <- 0 until 20) {
+    val coin     = rnd.nextInt(3)*5
+    val isNickel = coin == 5
+    val isDime   = coin == 10
+
+    // Advance circuit
+    poke(c.io.nickel, if (isNickel) 1 else 0)
+    poke(c.io.dime,   if (isDime) 1 else 0)
+    step(1)
+
+    // Advance model
+    money = if (isValid) 0 else money + coin
+    isValid = money >= 20
+
+    // Compare
+    expect(c.io.valid, if (isValid) 1 else 0)
+  }
+}


### PR DESCRIPTION
Adding VendingMachineSwitch to launcher and adding VendingMachineSwitch.scala to problems.

Close if you wanted to delete VendingMachineSwitch. Either ./run-problems.sh VendingMachineSwitch should work (this patch), or it shouldn't be in problems.