### PR TITLE
Eclipse Scala IDE: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 *.out
 /bin/
 target
+
+# Eclipse files
+.cache-main
+.cache-tests
+.classpath
+.project
+.settings/


### PR DESCRIPTION
It's nice to have a clean git status when working with the Eclipse IDE.

Also, it's useful to have an example of what files to ignore for the various IDE's and editors out there.