### PR TITLE
Chisel 3: import chisel3 explicitly

### DIFF
--- a/src/test/scala/examples/Risc.scala
+++ b/src/test/scala/examples/Risc.scala
@@ -26,7 +26,7 @@ class RiscTests(c: Risc) extends PeekPokeTester(c) {
     Cat(op, UInt(rc, 8), UInt(ra, 8), UInt(rb, 8))
 */
 
-  def I (op: Chisel.UInt, rc: Int, ra: Int, rb: Int) = 
+  def I (op: chisel3.UInt, rc: Int, ra: Int, rb: Int) = 
     ((op.litValue() & 1) << 24) | ((rc & Integer.parseInt("FF", 16)) << 16) | ((ra & Integer.parseInt("FF", 16)) << 8) | (rb & Integer.parseInt("FF", 16))
   val app  = Array(I(c.imm_op,   1, 0, 1), // r1 <- 1
                    I(c.add_op,   1, 1, 1), // r1 <- r1 + r1

--- a/src/test/scala/problems/Accumulator.scala
+++ b/src/test/scala/problems/Accumulator.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class AccumulatorTests(c: Accumulator) extends PeekPokeTester(c) {
   var tot = 0

--- a/src/test/scala/problems/Adder.scala
+++ b/src/test/scala/problems/Adder.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class AdderTests(c: Adder) extends PeekPokeTester(c) {
   for (i <- 0 until 10) {

--- a/src/test/scala/problems/Counter.scala
+++ b/src/test/scala/problems/Counter.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class CounterTest(c: Counter) extends PeekPokeTester(c) {
   val maxInt  = 16

--- a/src/test/scala/problems/DynamicMemorySearch.scala
+++ b/src/test/scala/problems/DynamicMemorySearch.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class DynamicMemorySearchTests(c: DynamicMemorySearch) extends PeekPokeTester(c) {
   val list = Array.fill(c.n){ 0 }

--- a/src/test/scala/problems/LFSR16.scala
+++ b/src/test/scala/problems/LFSR16.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class LFSR16Tests(c: LFSR16) extends PeekPokeTester(c) {
   var res = 1

--- a/src/test/scala/problems/Launcher.scala
+++ b/src/test/scala/problems/Launcher.scala
@@ -1,8 +1,8 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel._
-import Chisel.iotesters.Driver
+import chisel3._
+import chisel3.iotesters.Driver
 import utils.TutorialRunner
 
 object Launcher {

--- a/src/test/scala/problems/Max2.scala
+++ b/src/test/scala/problems/Max2.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 // Problem:
 //

--- a/src/test/scala/problems/MaxN.scala
+++ b/src/test/scala/problems/MaxN.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 // Problem:
 //

--- a/src/test/scala/problems/Memo.scala
+++ b/src/test/scala/problems/Memo.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class MemoTests(c: Memo) extends PeekPokeTester(c) {
   def rd(addr: Int, data: Int) = {

--- a/src/test/scala/problems/Mul.scala
+++ b/src/test/scala/problems/Mul.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class MulTests(c: Mul) extends PeekPokeTester(c) {
   val maxInt  = 1 << 4

--- a/src/test/scala/problems/Mux2.scala
+++ b/src/test/scala/problems/Mux2.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class Mux2Tests(c: Mux2) extends PeekPokeTester(c) {
   for (s <- 0 until 2) {

--- a/src/test/scala/problems/Mux4.scala
+++ b/src/test/scala/problems/Mux4.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class Mux4Tests(c: Mux4) extends PeekPokeTester(c) {
   for (s0 <- 0 until 2) {

--- a/src/test/scala/problems/RealGCD.scala
+++ b/src/test/scala/problems/RealGCD.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class RealGCDTests(c: RealGCD) extends PeekPokeTester(c) {
   val inputs = List( (48, 32), (7, 3), (100, 10) )

--- a/src/test/scala/problems/SingleEvenFilter.scala
+++ b/src/test/scala/problems/SingleEvenFilter.scala
@@ -1,8 +1,8 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel._
-import Chisel.iotesters.PeekPokeTester
+import chisel3._
+import chisel3.iotesters.PeekPokeTester
 
 class SingleEvenFilterTests[T <: UInt](c: SingleEvenFilter[T]) extends PeekPokeTester(c) {
   val maxInt  = 1 << 16

--- a/src/test/scala/problems/VecShiftRegister.scala
+++ b/src/test/scala/problems/VecShiftRegister.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VecShiftRegisterTests(c: VecShiftRegister) extends PeekPokeTester(c) {
   val reg     = Array.fill(4){ 0 }

--- a/src/test/scala/problems/VecShiftRegisterParam.scala
+++ b/src/test/scala/problems/VecShiftRegisterParam.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VecShiftRegisterParamTests(c: VecShiftRegisterParam) extends PeekPokeTester(c) {
   val reg = Array.fill(c.n){ 0 }

--- a/src/test/scala/problems/VecShiftRegisterSimple.scala
+++ b/src/test/scala/problems/VecShiftRegisterSimple.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VecShiftRegisterSimpleTests(c: VecShiftRegisterSimple) extends PeekPokeTester(c) {
   val reg = Array.fill(4){ 0 }

--- a/src/test/scala/problems/VendingMachine.scala
+++ b/src/test/scala/problems/VendingMachine.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VendingMachineTests(c: VendingMachine) extends PeekPokeTester(c) {
   var money = 0

--- a/src/test/scala/problems/VendingMachineSwitch.scala
+++ b/src/test/scala/problems/VendingMachineSwitch.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package problems
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VendingMachineSwitchTests(c: VendingMachineSwitch) extends PeekPokeTester(c) {
   var money = 0

--- a/src/test/scala/solutions/Accumulator.scala
+++ b/src/test/scala/solutions/Accumulator.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
 class AccumulatorTests(c: Accumulator) extends PeekPokeTester(c) {
   var tot = 0

--- a/src/test/scala/solutions/Adder.scala
+++ b/src/test/scala/solutions/Adder.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
 class AdderTests(c: Adder) extends PeekPokeTester(c) {
   for (i <- 0 until 10) {

--- a/src/test/scala/solutions/Counter.scala
+++ b/src/test/scala/solutions/Counter.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
 class CounterTest(c: Counter) extends PeekPokeTester(c) {
   val maxInt  = 16

--- a/src/test/scala/solutions/DynamicMemorySearch.scala
+++ b/src/test/scala/solutions/DynamicMemorySearch.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class DynamicMemorySearchTests(c: DynamicMemorySearch) extends PeekPokeTester(c) {
   val list = Array.fill(c.n){ 0 }

--- a/src/test/scala/solutions/LFSR16.scala
+++ b/src/test/scala/solutions/LFSR16.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class LFSR16Tests(c: LFSR16) extends PeekPokeTester(c) {
   var res = 1

--- a/src/test/scala/solutions/Launcher.scala
+++ b/src/test/scala/solutions/Launcher.scala
@@ -1,8 +1,8 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel._
-import Chisel.iotesters.Driver
+import chisel3._
+import chisel3.iotesters.Driver
 import utils.TutorialRunner
 
 object Launcher {

--- a/src/test/scala/solutions/Max2.scala
+++ b/src/test/scala/solutions/Max2.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 // Problem:
 //

--- a/src/test/scala/solutions/MaxN.scala
+++ b/src/test/scala/solutions/MaxN.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 // Problem:
 //

--- a/src/test/scala/solutions/Memo.scala
+++ b/src/test/scala/solutions/Memo.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class MemoTests(c: Memo) extends PeekPokeTester(c) {
   def rd(addr: Int, data: Int) = {

--- a/src/test/scala/solutions/Mul.scala
+++ b/src/test/scala/solutions/Mul.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class MulTests(c: Mul) extends PeekPokeTester(c) {
   val maxInt  = 1 << 4

--- a/src/test/scala/solutions/Mux2.scala
+++ b/src/test/scala/solutions/Mux2.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class Mux2Tests(c: Mux2) extends PeekPokeTester(c) {
   for (s <- 0 until 2) {

--- a/src/test/scala/solutions/Mux4.scala
+++ b/src/test/scala/solutions/Mux4.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class Mux4Tests(c: Mux4) extends PeekPokeTester(c) {
   for (s0 <- 0 until 2) {

--- a/src/test/scala/solutions/RealGCD.scala
+++ b/src/test/scala/solutions/RealGCD.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class RealGCDTests(c: RealGCD) extends PeekPokeTester(c) {
   val inputs = List( (48, 32), (7, 3), (100, 10) )

--- a/src/test/scala/solutions/SingleEvenFilter.scala
+++ b/src/test/scala/solutions/SingleEvenFilter.scala
@@ -1,8 +1,8 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel._
-import Chisel.iotesters.PeekPokeTester
+import chisel3._
+import chisel3.iotesters.PeekPokeTester
 
 class SingleEvenFilterTests[T <: UInt](c: SingleEvenFilter[T]) extends PeekPokeTester(c) {
   val maxInt  = 1 << 16

--- a/src/test/scala/solutions/VecShiftRegister.scala
+++ b/src/test/scala/solutions/VecShiftRegister.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VecShiftRegisterTests(c: VecShiftRegister) extends PeekPokeTester(c) {
   val reg     = Array.fill(4){ 0 }

--- a/src/test/scala/solutions/VecShiftRegisterParam.scala
+++ b/src/test/scala/solutions/VecShiftRegisterParam.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VecShiftRegisterParamTests(c: VecShiftRegisterParam) extends PeekPokeTester(c) {
   val reg = Array.fill(c.n){ 0 }

--- a/src/test/scala/solutions/VecShiftRegisterSimple.scala
+++ b/src/test/scala/solutions/VecShiftRegisterSimple.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VecShiftRegisterSimpleTests(c: VecShiftRegisterSimple) extends PeekPokeTester(c) {
   val reg = Array.fill(4){ 0 }

--- a/src/test/scala/solutions/VendingMachine.scala
+++ b/src/test/scala/solutions/VendingMachine.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VendingMachineTests(c: VendingMachine) extends PeekPokeTester(c) {
   var money = 0

--- a/src/test/scala/solutions/VendingMachineSwitch.scala
+++ b/src/test/scala/solutions/VendingMachineSwitch.scala
@@ -1,7 +1,7 @@
 // See LICENSE.txt for license details.
 package solutions
 
-import Chisel.iotesters.PeekPokeTester
+import chisel3.iotesters.PeekPokeTester
 
 class VendingMachineSwitchTests(c: VendingMachineSwitch) extends PeekPokeTester(c) {
   var money = 0


### PR DESCRIPTION
If I understand the Chisel 2 to 3 migration guide, we should explicitly import chisel3 instead of Chisel.