### PR TITLE
Update deprecated constructs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,36 @@
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Int)) if scalaMajor < 12 => Seq()
+      case _ => Seq("-Xsource:2.11")
+    }
+  }
+}
+
+def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // Scala 2.12 requires Java 8. We continue to generate
+    //  Java 7 compatible code for Scala 2.11
+    //  for compatibility with old clients.
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Int)) if scalaMajor < 12 =>
+        Seq("-source", "1.7", "-target", "1.7")
+      case _ =>
+        Seq("-source", "1.8", "-target", "1.8")
+    }
+  }
+}
+
 organization := "edu.berkeley.cs"
 
 version := "3.1-SNAPSHOT"
 
 name := "chisel-tutorial"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
 
@@ -26,6 +52,10 @@ resolvers ++= Seq(
 // Recommendations from http://www.scalatest.org/user_guide/using_scalatest_with_sbt
 logBuffered in Test := false
 
-// Disable parallel execution when running te
+// Disable parallel execution when running tests.
 //  Running tests in parallel on Jenkins currently fails.
 parallelExecution in Test := false
+
+scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
+
+javacOptions ++= javacOptionsVersion(scalaVersion.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.12
+sbt.version = 0.13.16

--- a/src/main/scala/examples/Adder.scala
+++ b/src/main/scala/examples/Adder.scala
@@ -2,7 +2,6 @@
 package examples
 
 import chisel3._
-import chisel3.util._
 
 //A n-bit adder with carry in and carry out
 class Adder(val n:Int) extends Module {
@@ -32,6 +31,6 @@ class Adder(val n:Int) extends Module {
     carry(i+1) := FAs(i).cout
     sum(i) := FAs(i).sum.toBool()
   }
-  io.Sum := Cat(sum.reverse)
+  io.Sum := sum.asUInt
   io.Cout := carry(n)
 }

--- a/src/main/scala/examples/Adder4.scala
+++ b/src/main/scala/examples/Adder4.scala
@@ -36,6 +36,6 @@ class Adder4 extends Module {
   Adder3.io.a := io.A(3)
   Adder3.io.b := io.B(3)
   Adder3.io.cin := Adder2.io.cout
-  io.Sum := Cat(Adder3.io.sum, s2).asUInt()
+  io.Sum := Cat(Adder3.io.sum, s2).asUInt
   io.Cout := Adder3.io.cout
 }

--- a/src/main/scala/examples/SimpleALU.scala
+++ b/src/main/scala/examples/SimpleALU.scala
@@ -30,7 +30,7 @@ class BasicALU extends Module {
   } .elsewhen (io.opcode === 8.U) {
     io.out := io.a < io.b //set on A less than B
   } .otherwise { 
-    io.out :=  (io.a === io.b).asUInt() //set on A equal to B
+    io.out :=  (io.a === io.b).asUInt //set on A equal to B
   }
 }
 

--- a/src/main/scala/examples/Tbl.scala
+++ b/src/main/scala/examples/Tbl.scala
@@ -8,6 +8,6 @@ class Tbl extends Module {
     val addr = Input(UInt(8.W))
     val out  = Output(UInt(8.W))
   })
-  val r = Wire(init = Vec(Range(0, 256).map(_.asUInt(8.W))))
+  val r = VecInit(Range(0, 256).map(_.asUInt(8.W)))
   io.out := r(io.addr)
 }

--- a/src/main/scala/examples/VecSearch.scala
+++ b/src/main/scala/examples/VecSearch.scala
@@ -12,7 +12,7 @@ class VecSearch extends Module {
     val out = Output(UInt(4.W))
   })
   val index = RegInit(0.U(3.W))
-  val elts  = Wire(init = Vec(VecSearchTest.pattern.map(_.asUInt(4.W))))
+  val elts  = VecInit(VecSearchTest.pattern.map(_.asUInt(4.W)))
   index := index + 1.U
   io.out := elts(index)
 }


### PR DESCRIPTION
replace Cat() with asUInt
remove unneeded Wire() wrappers
use VecInit() where instructed
update build.sbt to support Scala 2.12