### PR TITLE
solutions/VecShiftRegisterParam: Use parameter for initialization

### DIFF
--- a/src/main/scala/solutions/VecShiftRegisterParam.scala
+++ b/src/main/scala/solutions/VecShiftRegisterParam.scala
@@ -15,7 +15,7 @@ class VecShiftRegisterParam(val n: Int, val w: Int) extends Module {
     val out = Output(UInt(w.W))
   })
 
-  val initValues = Seq.fill(n) { 0.U(8.W) }
+  val initValues = Seq.fill(n) { 0.U(w.W) }
   val delays = RegInit(Vec(initValues))
 
   for (i <- n-1 to 1 by -1) {


### PR DESCRIPTION
Use parameter 'w' instead of hardcoding registers to be 8 bit wide.