### PR TITLE
Bump version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 
 organization := "edu.berkeley.cs"
 
-version := "3.1-SNAPSHOT"
+version := "3.2-SNAPSHOT"
 
 name := "chisel-tutorial"
 


### PR DESCRIPTION
We should bump the internal version as well - its code hasn't changed, but its dependent code (and hence its behavior) has.