### PR TITLE
Scala cleanup

### DIFF
--- a/src/main/scala/examples/Stack.scala
+++ b/src/main/scala/examples/Stack.scala
@@ -4,10 +4,6 @@ package examples
 import chisel3._
 import chisel3.util.log2Ceil
 
-import scala.collection.mutable.HashMap
-import scala.collection.mutable.{Stack => ScalaStack}
-import scala.util.Random
-
 class Stack(val depth: Int) extends Module {
   val io = IO(new Bundle {
     val push    = Input(Bool())

--- a/src/test/scala/examples/Adder4Tests.scala
+++ b/src/test/scala/examples/Adder4Tests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class Adder4Tests(c: Adder4) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/ByteSelectorTests.scala
+++ b/src/test/scala/examples/ByteSelectorTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class ByteSelectorTests(c: ByteSelector) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/CombinationalTests.scala
+++ b/src/test/scala/examples/CombinationalTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class CombinationalTests(c: Combinational) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/DarkenTests.scala
+++ b/src/test/scala/examples/DarkenTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class DarkenTests(c: Darken, infile: java.io.InputStream, outfilename: String) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/EnableShiftRegisterTests.scala
+++ b/src/test/scala/examples/EnableShiftRegisterTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class EnableShiftRegisterTests(c: EnableShiftRegister) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/FullAdderTests.scala
+++ b/src/test/scala/examples/FullAdderTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class FullAdderTests(c: FullAdder) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/FunctionalityTests.scala
+++ b/src/test/scala/examples/FunctionalityTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class FunctionalityTests(c: Functionality) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/GCDTests.scala
+++ b/src/test/scala/examples/GCDTests.scala
@@ -1,5 +1,4 @@
 // See LICENSE.txt for license details.
-
 package examples
 
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}

--- a/src/test/scala/examples/HiLoMultiplierTests.scala
+++ b/src/test/scala/examples/HiLoMultiplierTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class HiLoMultiplierTests(c: HiLoMultiplier) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/Image.scala
+++ b/src/test/scala/examples/Image.scala
@@ -1,8 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
-import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 import scala.io.Source
 import java.io.{File, FileOutputStream, InputStream}
 

--- a/src/test/scala/examples/LifeTests.scala
+++ b/src/test/scala/examples/LifeTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{Driver, PeekPokeTester}
 import org.scalatest.FreeSpec
 

--- a/src/test/scala/examples/LogShifterTests.scala
+++ b/src/test/scala/examples/LogShifterTests.scala
@@ -1,8 +1,7 @@
 // See LICENSE.txt for license details.
 package examples
 
-
-import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
+import chisel3.iotesters.PeekPokeTester
 
 class LogShifterTests(c: LogShifter) extends PeekPokeTester(c) {
 }

--- a/src/test/scala/examples/ParityTests.scala
+++ b/src/test/scala/examples/ParityTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class ParityTests(c: Parity) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/ResetShiftRegisterTests.scala
+++ b/src/test/scala/examples/ResetShiftRegisterTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class ResetShiftRegisterTests(c: ResetShiftRegister) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/RouterTests.scala
+++ b/src/test/scala/examples/RouterTests.scala
@@ -1,5 +1,4 @@
 // See LICENSE for license details.
-
 package examples
 
 import chisel3._

--- a/src/test/scala/examples/ShiftRegisterTests.scala
+++ b/src/test/scala/examples/ShiftRegisterTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class ShiftRegisterTests(c: ShiftRegister) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/SimpleALUTests.scala
+++ b/src/test/scala/examples/SimpleALUTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class SimpleALUTests(c: SimpleALU) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/StackTests.scala
+++ b/src/test/scala/examples/StackTests.scala
@@ -1,11 +1,8 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
-import scala.collection.mutable.HashMap
-import scala.collection.mutable.{Stack => ScalaStack}
-import scala.util.Random
+import scala.collection.mutable.{ArrayStack => ScalaStack}
 
 class StackTestsOrig(c: Stack) extends PeekPokeTester(c) {
   var nxtDataOut = 0

--- a/src/test/scala/examples/TblTests.scala
+++ b/src/test/scala/examples/TblTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class TblTests(c: Tbl) extends PeekPokeTester(c) {

--- a/src/test/scala/examples/VecSearchTests.scala
+++ b/src/test/scala/examples/VecSearchTests.scala
@@ -1,7 +1,6 @@
 // See LICENSE.txt for license details.
 package examples
 
-
 import chisel3.iotesters.{PeekPokeTester, Driver, ChiselFlatSpec}
 
 class VecSearchTests(c: VecSearch) extends PeekPokeTester(c) {

--- a/src/test/scala/utils/TutorialRunner.scala
+++ b/src/test/scala/utils/TutorialRunner.scala
@@ -1,5 +1,4 @@
 // See LICENSE.txt for license details.
-
 package utils
 
 import scala.collection.mutable.ArrayBuffer


### PR DESCRIPTION
Replace deprecated Scala Stack with ArrayStack.
Remove unused imports.
Delete extraneous blank lines.