### PR TITLE
update test module paths in challenge comments

### DIFF
--- a/src/main/scala/problems/Max2.scala
+++ b/src/main/scala/problems/Max2.scala
@@ -6,7 +6,7 @@ import chisel3._
 // Problem:
 //
 // Implement a test for this module. Please edit:
-// .../chisel_tutorial/src/test/scala/problems/Max2.scala
+// .../chisel_tutorial/src/test/scala/problems/Max2Tests.scala
 //
 class Max2 extends Module {
   val io = IO(new Bundle {

--- a/src/main/scala/problems/MaxN.scala
+++ b/src/main/scala/problems/MaxN.scala
@@ -6,7 +6,7 @@ import chisel3._
 // Problem:
 //
 // Implement test for this module. Please edit:
-// .../chisel-tutorial/src/test/scala/problems/MaxN.scala
+// .../chisel-tutorial/src/test/scala/problems/MaxNTests.scala
 //
 class MaxN(val n: Int, val w: Int) extends Module {
 

--- a/src/main/scala/solutions/Max2.scala
+++ b/src/main/scala/solutions/Max2.scala
@@ -6,7 +6,7 @@ import chisel3._
 // Problem:
 //
 // Implement a test for this module. Please edit:
-// .../chisel_tutorial/src/test/scala/problems/Max2.scala
+// .../chisel_tutorial/src/test/scala/problems/Max2Tests.scala
 //
 class Max2 extends Module {
   val io = IO(new Bundle {

--- a/src/main/scala/solutions/MaxN.scala
+++ b/src/main/scala/solutions/MaxN.scala
@@ -6,7 +6,7 @@ import chisel3._
 // Problem:
 //
 // Implement test for this module. Please edit:
-// .../chisel-tutorial/src/test/scala/problems/MaxN.scala
+// .../chisel-tutorial/src/test/scala/problems/MaxNTests.scala
 //
 class MaxN(val n: Int, val w: Int) extends Module {
 


### PR DESCRIPTION
Several of the challenges specify a path to where tests should be written, such as follow:
```
// Problem:
// Problem:
//
//
// Implement a test for this module. Please edit:
// Implement a test for this module. Please edit:
// .../chisel_tutorial/src/test/scala/problems/Max2.scala
//
```

These paths were broken so I fixed them.

All that was needed was adding `Tests` to the ends of the filenames (before `.scala` of course).

I updated both the problems and solutions to reference the correct path.