### PR TITLE
ignore files created when viewing doc/tutorial/*.tex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ target
 .classpath
 .project
 .settings/
+
+# ignore files created when viewing doc/tutorial/*.tex
+doc/tutorial/*.aux
+doc/tutorial/*.log
+doc/tutorial/*.pdf
+doc/tutorial/*.synctex.gz


### PR DESCRIPTION
TeXShop, when editing/viewing a file, generates several unnecessary files in the `doc/tutorial` directory. More specifically, these files end with `.aux`, `.log`, `.synctex.gz`.

Since I assume that this is a popular TeX editor, I assumed that others might have the same annoyance, so I added the files to the project's `.gitignore`.

I also added `doc/tutorial/*.pdf` to the gitignore since I assume that many tutorial-followers will convert the tex to a pdf before reading it.

