### PR TITLE
Disable sbt crash on System.exit().

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,3 +61,5 @@ parallelExecution in Test := false
 scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
 
 javacOptions ++= javacOptionsVersion(scalaVersion.value)
+
+trapExit := false


### PR DESCRIPTION
This addresses part of issue #129.

sbt.TrapExitSecurityException thrown at "sbt run" - https://stackoverflow.com/questions/21464673/sbt-trapexitsecurityexception-thrown-at-sbt-run