### PR TITLE
Update deprecations

### DIFF
--- a/src/main/scala/examples/Adder.scala
+++ b/src/main/scala/examples/Adder.scala
@@ -29,7 +29,7 @@ class Adder(val n:Int) extends Module {
     FAs(i).b := io.B(i)
     FAs(i).cin := carry(i)
     carry(i+1) := FAs(i).cout
-    sum(i) := FAs(i).sum.toBool()
+    sum(i) := FAs(i).sum.asBool()
   }
   io.Sum := sum.asUInt
   io.Cout := carry(n)

--- a/src/main/scala/examples/Adder.scala
+++ b/src/main/scala/examples/Adder.scala
@@ -29,7 +29,7 @@ class Adder(val n:Int) extends Module {
     FAs(i).b := io.B(i)
     FAs(i).cin := carry(i)
     carry(i+1) := FAs(i).cout
-    sum(i) := FAs(i).sum.asBool()
+    sum(i) := FAs(i).sum.asBool
   }
   io.Sum := sum.asUInt
   io.Cout := carry(n)

--- a/src/main/scala/examples/EnableShiftRegister.scala
+++ b/src/main/scala/examples/EnableShiftRegister.scala
@@ -13,7 +13,7 @@ class EnableShiftRegister extends Module {
   val r1 = Reg(UInt())
   val r2 = Reg(UInt())
   val r3 = Reg(UInt())
-  when(reset.toBool) {
+  when(reset.asBool) {
     r0 := 0.U(4.W)
     r1 := 0.U(4.W)
     r2 := 0.U(4.W)

--- a/src/main/scala/solutions/SingleEvenFilter.scala
+++ b/src/main/scala/solutions/SingleEvenFilter.scala
@@ -32,7 +32,7 @@ object SingleFilter {
 
 object EvenFilter {
   def apply[T <: UInt](dtype: T) = 
-    Module(new PredicateFilter(dtype, (x: T) => x(0).toBool))
+    Module(new PredicateFilter(dtype, (x: T) => x(0).asBool))
 }
 
 class SingleEvenFilter[T <: UInt](dtype: T) extends Filter(dtype) {

--- a/src/test/scala/utils/TutorialRunner.scala
+++ b/src/test/scala/utils/TutorialRunner.scala
@@ -4,6 +4,18 @@ package utils
 import scala.collection.mutable.ArrayBuffer
 import chisel3.iotesters._
 
+object OptionsCopy {
+  def apply(t: TesterOptionsManager): TesterOptionsManager = {
+    new TesterOptionsManager {
+      testerOptions = t.testerOptions.copy()
+      interpreterOptions = t.interpreterOptions.copy()
+      chiselOptions = t.chiselOptions.copy()
+      firrtlOptions = t.firrtlOptions.copy()
+      treadleOptions = t.treadleOptions.copy()
+    }
+  }
+}
+
 object TutorialRunner {
   def apply(section: String, tutorialMap: Map[String, TesterOptionsManager => Boolean], args: Array[String]): Unit = {
     var successful = 0
@@ -38,8 +50,7 @@ object TutorialRunner {
           println(s"Starting tutorial $testName")
           try {
             // Start with a (relatively) clean set of options.
-            val testOptionsManager = new TesterOptionsManager()
-            testOptionsManager.parse(args)
+            val testOptionsManager = OptionsCopy(optionsManager)
             testOptionsManager.setTopName(testName)
             testOptionsManager.setTargetDirName(s"test_run_dir/$section/$testName")
             if(test(testOptionsManager)) {

--- a/src/test/scala/utils/TutorialRunner.scala
+++ b/src/test/scala/utils/TutorialRunner.scala
@@ -37,9 +37,11 @@ object TutorialRunner {
         case Some(test) =>
           println(s"Starting tutorial $testName")
           try {
-            optionsManager.setTopName(testName)
-            optionsManager.setTargetDirName(s"test_run_dir/$section/$testName")
-            if(test(optionsManager)) {
+            // Start with a (relatively) clean set of options.
+            val testOptionsManager = new TesterOptionsManager()
+            testOptionsManager.setTopName(testName)
+            testOptionsManager.setTargetDirName(s"test_run_dir/$section/$testName")
+            if(test(testOptionsManager)) {
               successful += 1
             }
             else {

--- a/src/test/scala/utils/TutorialRunner.scala
+++ b/src/test/scala/utils/TutorialRunner.scala
@@ -39,6 +39,7 @@ object TutorialRunner {
           try {
             // Start with a (relatively) clean set of options.
             val testOptionsManager = new TesterOptionsManager()
+            testOptionsManager.parse(args)
             testOptionsManager.setTopName(testName)
             testOptionsManager.setTargetDirName(s"test_run_dir/$section/$testName")
             if(test(testOptionsManager)) {


### PR DESCRIPTION
Replace `toBool` with `asBool`.
Ensure each test run uses a fresh `TesterOptionsManager` so we don't end up with:
```
firrtl.options.OptionsException: Multiply defined input FIRRTL sources. More than one of the following was found:
    - an input file (0 times):  -i, --input-file,    FirrtlFileAnnotation
    - FIRRTL source (0 times):      --firrtl-source, FirrtlSourceAnnotation
    - FIRRTL circuit (2 times):                      FirrtlCircuitAnnotation
```
