### PR TITLE
Bump SNAPSHOT versions for master branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,25 +26,25 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 
 organization := "edu.berkeley.cs"
 
-version := "3.2-SNAPSHOT"
+version := "3.3-SNAPSHOT"
 
 name := "chisel-tutorial"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+crossScalaVersions := Seq("2.12.10", "2.11.12")
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 // The following are the default development versions, not the "release" versions.
-val defaultVersions = Map(
-  "chisel3" -> "3.2-SNAPSHOT",
-  "chisel-iotesters" -> "1.3-SNAPSHOT"
+val defaultVersions = Seq(
+  "chisel3" -> "3.3-SNAPSHOT",
+  "chisel-iotesters" -> "1.4-SNAPSHOT"
   )
 
-libraryDependencies ++= (Seq("chisel3","chisel-iotesters").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
+libraryDependencies ++= defaultVersions.map { case (dep, ver) =>
+  "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", ver) }
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.3.7


### PR DESCRIPTION
Make Scala 2.12 the default version.
Use the newest SNAPSHOT versions of chisel3 and chisel-iotesters.
Use sbt 1.3.7 (see #154).
Use chisel-testers libraryDependencies format.

**NOTE**: Don't merge this into release until we've published the 3.3.0 version of chisel.
